### PR TITLE
fix: Support subarrays in Sia constructor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@timeleap/sia",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/buffer.ts
+++ b/src/buffer.ts
@@ -8,7 +8,11 @@ export class Buffer {
     this.size = uint8Array.length;
     this.content = uint8Array;
     this.offset = 0;
-    this.dataView = new DataView(uint8Array.buffer);
+    this.dataView = new DataView(
+      uint8Array.buffer,
+      uint8Array.byteOffset,
+      uint8Array.byteLength,
+    );
   }
 
   static new(size: number = 32 * 1024 * 1024) {

--- a/tests/sia.test.ts
+++ b/tests/sia.test.ts
@@ -314,3 +314,18 @@ describe("Sia read methods - insufficient data error tests", () => {
     );
   });
 });
+
+describe("Sia - Memory safety", () => {
+  it("does not write outside subarray boundaries", () => {
+    const byteArray = new Uint8Array(8).fill(0x1);
+    const sub = byteArray.subarray(4);
+    const sia = new Sia(sub);
+
+    sia.addUInt32(1);
+
+    const untouchedRegion = byteArray.slice(0, 4);
+    const expected = new Uint8Array(4).fill(0x1);
+
+    expect(untouchedRegion).toEqual(expected);
+  });
+});


### PR DESCRIPTION
## Context

The Sia constructor previously created a `DataView` directly from a Uint8Array.buffer, assuming it always started at `byteOffset = 0`. This worked fine in Node.js and V8 environments when using full arrays, but silently broke when passing subarrays. 

The issue was discovered in bun with their websocket implementation, where `subarray()` returns a view with a non-zero `byteOffset`.

### This led to:

- Subtle memory corruption
- `Read` and `write` methods operating on incorrect regions
- WebSocket decoding failures in Bun due to misaligned buffers

## Proposed solution
We should initialize DataView using:
```js
new DataView(buffer, byteOffset, byteLength)
```
This guarantees that even subarrays point to the exact memory region they represent, without bleeding into other parts of the buffer.
## Tests
- Added a dedicated memory suite for future issues
- Confirmed memory outside subarray boundaries is no longer modified
- Used a custom plugin in Bun to simulate and validate the bug
## Notes

- The issue doesn’t surface in Node.js due to how `slice()` and `subarray()` behave under the hood with Buffer
- In Bun, `Uint8Array.subarray()` uses `byteOffset` correctly, which surfaced the bug